### PR TITLE
Issue #198 - Refactor comment pagination to use data source paging

### DIFF
--- a/9.0/digioz.Portal.Dal/Services/CommentService.cs
+++ b/9.0/digioz.Portal.Dal/Services/CommentService.cs
@@ -140,7 +140,7 @@ namespace digioz.Portal.Dal.Services
                 .ToList();
         }
 
-        public List<Comment> GetPagedFiltered(int pageNumber, int pageSize, bool? visibleFilter, bool? approvedFilter, string referenceTypeFilter, out int totalCount)
+        public List<Comment> GetPagedFiltered(int pageNumber, int pageSize, bool? visibleFilter, bool? approvedFilter, string referenceTypeFilter, out int totalCount, bool sortByCreatedDate = false)
         {
             var query = _context.Comments.AsNoTracking().AsQueryable();
 
@@ -176,8 +176,10 @@ namespace digioz.Portal.Dal.Services
                 query = query.Where(c => c.ReferenceType == referenceTypeFilter);
             }
 
-            // Order by modified date
-            query = query.OrderByDescending(c => c.ModifiedDate ?? c.CreatedDate);
+            // Order by date
+            query = sortByCreatedDate
+                ? query.OrderByDescending(c => c.CreatedDate)
+                : query.OrderByDescending(c => c.ModifiedDate ?? c.CreatedDate);
 
             // Get total count
             totalCount = query.Count();

--- a/9.0/digioz.Portal.Dal/Services/Interfaces/ICommentService.cs
+++ b/9.0/digioz.Portal.Dal/Services/Interfaces/ICommentService.cs
@@ -38,8 +38,9 @@ namespace digioz.Portal.Dal.Services.Interfaces
         /// <param name="approvedFilter">Filter by approved status: null=all, true=approved only, false=not approved only</param>
         /// <param name="referenceTypeFilter">Filter by reference type (null or empty for all)</param>
         /// <param name="totalCount">Output parameter for total matching count</param>
+        /// <param name="sortByCreatedDate">When true, orders by CreatedDate instead of ModifiedDate</param>
         /// <returns>Filtered and paginated list of comments</returns>
-        List<Comment> GetPagedFiltered(int pageNumber, int pageSize, bool? visibleFilter, bool? approvedFilter, string referenceTypeFilter, out int totalCount);
+        List<Comment> GetPagedFiltered(int pageNumber, int pageSize, bool? visibleFilter, bool? approvedFilter, string referenceTypeFilter, out int totalCount, bool sortByCreatedDate = false);
         
         /// <summary>
         /// Gets distinct reference types for filtering purposes.

--- a/9.0/digioz.Portal.Web/Pages/Comments/Index.cshtml.cs
+++ b/9.0/digioz.Portal.Web/Pages/Comments/Index.cshtml.cs
@@ -1,4 +1,4 @@
-using System;
+ using System;
 using System.Collections.Generic;
 using System.Linq;
 using digioz.Portal.Bo;
@@ -38,18 +38,15 @@ namespace digioz.Portal.Web.Pages.Comments
             // Validate page number
             PageNumber = pageNumber > 0 ? pageNumber : 1;
 
-            // Get all comments ordered by newest first
-            var allComments = _commentService.GetAll()
-                .OrderByDescending(c => c.CreatedDate)
-                .ToList();
+            var pagedComments = _commentService.GetPagedFiltered(
+                PageNumber,
+                PageSize,
+                true,
+                true,
+                string.Empty,
+                out var totalCount);
 
-            TotalCount = allComments.Count;
-
-            // Apply pagination
-            var pagedComments = allComments
-                .Skip((PageNumber - 1) * PageSize)
-                .Take(PageSize)
-                .ToList();
+            TotalCount = totalCount;
 
             // Batch load all related data to avoid N+1 queries
             var userIds = pagedComments

--- a/9.0/digioz.Portal.Web/Pages/Comments/Index.cshtml.cs
+++ b/9.0/digioz.Portal.Web/Pages/Comments/Index.cshtml.cs
@@ -44,7 +44,8 @@ namespace digioz.Portal.Web.Pages.Comments
                 true,
                 true,
                 string.Empty,
-                out var totalCount);
+                out var totalCount,
+                sortByCreatedDate: true);
 
             TotalCount = totalCount;
 

--- a/9.0/digioz.Portal.Web/Pages/Comments/Index.cshtml.cs
+++ b/9.0/digioz.Portal.Web/Pages/Comments/Index.cshtml.cs
@@ -1,4 +1,4 @@
- using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using digioz.Portal.Bo;


### PR DESCRIPTION
Replaced in-memory pagination with GetPagedFiltered method to fetch only the required page of comments directly from the data source. This improves performance and reduces memory usage, especially for large comment sets. Total comment count is now retrieved from the service method's out parameter.